### PR TITLE
fix: fix Correct recognition of Class Variance Authority (CVA) props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # zolastic-component-library-experiment
 
+## 1.2.2
+
+### Patch Changes
+
+- Fixed a bug where props provided by Class Variance Authority (CVA) were not recognised by TypeScript. This fix ensures that CVA props are now correctly recognized, eliminating TypeScript errors. Additionally, variant props for CVA can now be autocompleted. A new 'transparent background' variant has also been added to the Tag component.
+
 ## 1.2.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zolastic-component-library-experiment",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Learning how to make a component library",
   "scripts": {
     "build:styles": "postcss src/components/styles.css -o dist/styles.css",

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -15,6 +15,8 @@ const tagVariants = cva(
           "border-primary-active bg-primary-accent text-primary hover:bg-primary-accent/50",
         secondary:
           "border-secondary-active bg-secondary-accent text-secondary hover:bg-secondary-accent/50",
+        transparentBackground:
+          "border-transparent bg-transparent text-text-default hover:bg-grey-300",
       },
     },
     defaultVariants: {
@@ -95,7 +97,7 @@ function CheckableTag({
   checkedTextColor = "#482384",
   onClickTag,
   className = "",
-  variant,
+  variant = "transparentBackground",
   disabled = false,
   icon = null,
   border = false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "declarationDir": "types",
     "sourceMap": true,
     "outDir": "dist",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
     "emitDeclarationOnly": true
   },


### PR DESCRIPTION
- This commit fixes a bug where TypeScript did not recognize props provided by CVA. Now, CVA props are correctly recognized, eliminating TypeScript errors. Additionally, enables autocompletion for variant props in CVA
- This commit adds a new 'transparent background' variant to the Tag component.